### PR TITLE
Fixed print statements to be compatible with python 3+

### DIFF
--- a/sample/AuthorizeIntentExamples/authorize_order.py
+++ b/sample/AuthorizeIntentExamples/authorize_order.py
@@ -17,21 +17,21 @@ class AuthorizeOrder(PayPalClient):
         request.request_body(self.build_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Status Code: ', response.status_code
-            print 'Status: ', response.result.status
-            print 'Order ID: ', response.result.id
-            print 'Authorization ID:', response.result.purchase_units[0].payments.authorizations[0].id
-            print 'Links:'
+            print('Status Code: ', response.status_code)
+            print('Status: ', response.result.status)
+            print('Order ID: ', response.result.id)
+            print('Authorization ID:', response.result.purchase_units[0].payments.authorizations[0].id)
+            print('Links:')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print 'Authorization Links:'
+            print('Authorization Links:')
             for link in response.result.purchase_units[0].payments.authorizations[0].links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print "Buyer:"
-            print "\tEmail Address: {}\n\tPhone Number: {}".format(response.result.payer.email_address,
-                                                                   response.result.payer.phone.phone_number.national_number)
+            print("Buyer:")
+            print("\tEmail Address: {}\n\tPhone Number: {}".format(response.result.payer.email_address,
+                                                                   response.result.payer.phone.phone_number.national_number))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 """This is the driver function which invokes the authorize_order function with valid approved order id to authorize

--- a/sample/AuthorizeIntentExamples/capture_order.py
+++ b/sample/AuthorizeIntentExamples/capture_order.py
@@ -17,14 +17,14 @@ class CaptureOrder(PayPalClient):
         request.request_body(self.build_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Status Code: ', response.status_code
-            print 'Status: ', response.result.status
-            print 'Capture ID: ', response.result.id
-            print 'Links: '
+            print('Status Code: ', response.status_code)
+            print('Status: ', response.result.status)
+            print('Capture ID: ', response.result.id)
+            print('Links: ')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 """This is the driver function which invokes the capture order function with valid authorization id to capture.

--- a/sample/AuthorizeIntentExamples/create_order.py
+++ b/sample/AuthorizeIntentExamples/create_order.py
@@ -133,18 +133,18 @@ class CreateOrder(PayPalClient):
         request.request_body(self.build_complete_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Order With Complete Payload:'
-            print 'Status Code:', response.status_code
-            print 'Status:', response.result.status
-            print 'Order ID:', response.result.id
-            print 'Intent:', response.result.intent
-            print 'Links:'
+            print('Order With Complete Payload:')
+            print('Status Code:', response.status_code)
+            print('Status:', response.result.status)
+            print('Order ID:', response.result.id)
+            print('Intent:', response.result.intent)
+            print('Links:')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print 'Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
-                                               response.result.purchase_units[0].amount.value)
+            print('Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
+                                               response.result.purchase_units[0].amount.value))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
     """This function can be used to create an order with minimum required request body"""
@@ -154,18 +154,18 @@ class CreateOrder(PayPalClient):
         request.request_body(self.build_minimum_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Order With Minimum Payload:'
-            print 'Status Code:', response.status_code
-            print 'Status:', response.result.status
-            print 'Order ID:', response.result.id
-            print 'Intent:', response.result.intent
-            print 'Links:'
+            print('Order With Minimum Payload:')
+            print('Status Code:', response.status_code)
+            print('Status:', response.result.status)
+            print('Order ID:', response.result.id)
+            print('Intent:', response.result.intent)
+            print('Links:')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print 'Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
-                                               response.result.purchase_units[0].amount.value)
+            print('Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
+                                               response.result.purchase_units[0].amount.value))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 """This is the driver function which invokes the createOrder function to create

--- a/sample/CaptureIntentExamples/capture_order.py
+++ b/sample/CaptureIntentExamples/capture_order.py
@@ -12,22 +12,22 @@ class CaptureOrder(PayPalClient):
         request = OrdersCaptureRequest(order_id)
         response = self.client.execute(request)
         if debug:
-            print 'Status Code: ', response.status_code
-            print 'Status: ', response.result.status
-            print 'Order ID: ', response.result.id
-            print 'Links: '
+            print('Status Code: ', response.status_code)
+            print('Status: ', response.result.status)
+            print('Order ID: ', response.result.id)
+            print('Links: ')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print 'Capture Ids: '
+            print('Capture Ids: ')
             for purchase_unit in response.result.purchase_units:
                 for capture in purchase_unit.payments.captures:
-                    print '\t', capture.id
-            print "Buyer:"
-            print "\tEmail Address: {}\n\tName: {}\n\tPhone Number: {}".format(response.result.payer.email_address,
+                    print('\t', capture.id)
+            print("Buyer:")
+            print("\tEmail Address: {}\n\tName: {}\n\tPhone Number: {}".format(response.result.payer.email_address,
                                                                            response.result.payer.name.given_name + " " + response.result.payer.name.surname,
-                                                                           response.result.payer.phone.phone_number.national_number)
+                                                                           response.result.payer.phone.phone_number.national_number))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 

--- a/sample/CaptureIntentExamples/create_order.py
+++ b/sample/CaptureIntentExamples/create_order.py
@@ -115,17 +115,17 @@ class CreateOrder(PayPalClient):
         request.request_body(self.build_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Status Code: ', response.status_code
-            print 'Status: ', response.result.status
-            print 'Order ID: ', response.result.id
-            print 'Intent: ', response.result.intent
-            print 'Links:'
+            print('Status Code: ', response.status_code)
+            print('Status: ', response.result.status)
+            print('Order ID: ', response.result.id)
+            print('Intent: ', response.result.intent)
+            print('Links:')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
-            print 'Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
-                                               response.result.purchase_units[0].amount.value)
+            print('Total Amount: {} {}'.format(response.result.purchase_units[0].amount.currency_code,
+                                               response.result.purchase_units[0].amount.value))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 """This is the driver function which invokes the createOrder function to create

--- a/sample/error_sample.py
+++ b/sample/error_sample.py
@@ -13,13 +13,13 @@ class CreateError(PayPalClient):
         body = {}
         request = OrdersCreateRequest()
         request.request_body(body)
-        print "Request Body:", body, "\n"
-        print "Response:"
+        print("Request Body:", body, "\n")
+        print("Response:")
         try:
             response = self.client.execute(request)
         except HttpError as h:
-            print "Status Code:", h.status_code
-            print self.pretty_print(h.message)
+            print("Status Code:", h.status_code)
+            print(self.pretty_print(h.message))
 
     def create_error_2(self):
         """
@@ -40,18 +40,18 @@ class CreateError(PayPalClient):
             }
         request = OrdersCreateRequest()
         request.request_body(body)
-        print "Request Body:\n", json.dumps(body, indent=4), "\n"
-        print "Response:"
+        print("Request Body:\n", json.dumps(body, indent=4), "\n")
+        print("Response:")
         response = ""
         try:
             response = self.client.execute(request)
         except HttpError as h:
-            print "Status Code: ", h.status_code
-            print self.pretty_print(h.message)
+            print("Status Code: ", h.status_code)
+            print(self.pretty_print(h.message))
 
 
-print "Calling create_error_1 (Body has no required parameters (intent, purchase_units))"
+print("Calling create_error_1 (Body has no required parameters (intent, purchase_units))")
 CreateError().create_error_1()
 
-print "\nExecuting create_error_2 (Body has invalid parameter value for intent)"
+print("\nExecuting create_error_2 (Body has invalid parameter value for intent)")
 CreateError().create_error_2()

--- a/sample/refund_order.py
+++ b/sample/refund_order.py
@@ -24,14 +24,14 @@ class RefundOrder(PayPalClient):
         request.request_body(self.build_request_body())
         response = self.client.execute(request)
         if debug:
-            print 'Status Code:', response.status_code
-            print 'Status:', response.result.status
-            print 'Order ID:', response.result.id
-            print 'Links:'
+            print('Status Code:', response.status_code)
+            print('Status:', response.result.status)
+            print('Order ID:', response.result.id)
+            print('Links:')
             for link in response.result.links:
                 print('\t{}: {}\tCall Type: {}'.format(link.rel, link.href, link.method))
             json_data = self.object_to_json(response.result)
-            print "json_data: ", json.dumps(json_data,indent=4)
+            print("json_data: ", json.dumps(json_data,indent=4))
         return response
 
 """This is the driver function which invokes the refund capture function. Capture Id value should be replaced with the valid capture id. """


### PR DESCRIPTION
**What problem :**
From a fresh start with python 3.6 the tests were failing because samples are written in the `print 'something'` fashion.

**What solution :**
This merge only adds parenthesis to the various print statements. 